### PR TITLE
Handle missing document id in testitem postprocessing

### DIFF
--- a/library/postprocess_testitem.py
+++ b/library/postprocess_testitem.py
@@ -58,6 +58,11 @@ def run(inputs: Dict[str, pd.DataFrame], config: dict) -> pd.DataFrame:
     }
     typed = coerce_types(testitem_df, base_schema)
 
+    if "document_chembl_id" not in typed.columns:
+        typed["document_chembl_id"] = pd.Series(
+            pd.NA, index=typed.index, dtype="string"
+        )
+
     if "all_names" in typed.columns:
         typed["all_names"] = typed["all_names"].fillna("")
     if "standard_inchi_key" in typed.columns:


### PR DESCRIPTION
## Summary
- ensure the testitem post-processing pipeline always exposes the document_chembl_id column before merging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d43fee3b788324adcd2107f9099b9a