### PR TITLE
Handle missing target columns

### DIFF
--- a/library/utils.py
+++ b/library/utils.py
@@ -57,6 +57,26 @@ def coerce_types(df: pd.DataFrame, spec: Dict[str, Any]) -> pd.DataFrame:
     return result
 
 
+def ensure_columns(
+    df: pd.DataFrame, columns: Sequence[str], type_map: Dict[str, Any] | None = None
+) -> pd.DataFrame:
+    result = df.copy()
+    column_types = type_map or {}
+    for column in columns:
+        if column in result.columns:
+            continue
+        resolved = _resolve_dtype(column_types.get(column, "string"))
+        if resolved in {"Int64", "int64"}:
+            result[column] = pd.Series(pd.NA, index=result.index, dtype="Int64")
+        elif resolved in {"boolean", "bool"}:
+            result[column] = pd.Series(pd.NA, index=result.index, dtype="boolean")
+        elif resolved == "string":
+            result[column] = pd.Series(pd.NA, index=result.index, dtype="string")
+        else:
+            result[column] = pd.Series(pd.NA, index=result.index, dtype=resolved)
+    return result
+
+
 def safe_merge(
     left: pd.DataFrame,
     right: pd.DataFrame,
@@ -104,4 +124,5 @@ __all__ = [
     "deduplicate",
     "finalize_aggregate_columns",
     "sort_dataframe",
+    "ensure_columns",
 ]

--- a/tests/test_postprocess_target.py
+++ b/tests/test_postprocess_target.py
@@ -46,3 +46,26 @@ def test_target_postprocess(target_inputs, test_config) -> None:
     expected = coerce_types(expected, type_map)
 
     pdt.assert_frame_equal(result, expected)
+
+
+def test_target_postprocess_missing_columns(test_config) -> None:
+    minimal = pd.DataFrame(
+        {
+            "target_chembl_id": ["T1"],
+            "uniprot_id_primary": ["P12345"],
+        }
+    )
+
+    inputs = {"target": minimal}
+
+    result = run(inputs, test_config)
+
+    output_columns = test_config["pipeline"]["target"]["output_columns"]
+    expected = pd.DataFrame([{column: pd.NA for column in output_columns}])
+    expected.loc[0, "target_chembl_id"] = "T1"
+    expected.loc[0, "uniprot_id_primary"] = "P12345"
+
+    type_map = test_config["pipeline"]["target"]["type_map"]
+    expected = coerce_types(expected, type_map)
+
+    pdt.assert_frame_equal(result, expected)


### PR DESCRIPTION
## Summary
- add an ``ensure_columns`` utility to backfill configured columns with typed nulls
- ensure target post-processing fills required columns before type coercion
- cover the missing column scenario with an additional unit test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d45e7fe99c8324865d3b084b7d7ad0