### PR TITLE
Harden document aggregation schema handling

### DIFF
--- a/library/postprocess_document.py
+++ b/library/postprocess_document.py
@@ -6,29 +6,23 @@ from typing import Dict
 import pandas as pd
 
 from .transforms import clean_pipe, to_text
-from .utils import coerce_types, finalize_aggregate_columns
+from .utils import coerce_types, ensure_columns, finalize_aggregate_columns
 
 logger = logging.getLogger(__name__)
 
 
+ACTIVITY_SCHEMA = {
+    "activity_chembl_id": "Int64",
+    "assay_chembl_id": "string",
+    "molecule_chembl_id": "string",
+    "document_chembl_id": "string",
+    "is_citation": "boolean",
+}
+
+
 def _prepare_activity(activity: pd.DataFrame) -> pd.DataFrame:
-    schema = {
-        "activity_chembl_id": "Int64",
-        "assay_chembl_id": "string",
-        "molecule_chembl_id": "string",
-        "document_chembl_id": "string",
-        "is_citation": "boolean",
-    }
     if activity.empty:
-        return pd.DataFrame(columns=schema.keys()).astype(
-            {
-                "activity_chembl_id": "Int64",
-                "assay_chembl_id": "string",
-                "molecule_chembl_id": "string",
-                "document_chembl_id": "string",
-                "is_citation": "boolean",
-            }
-        )
+        return pd.DataFrame(columns=ACTIVITY_SCHEMA.keys()).astype(ACTIVITY_SCHEMA)
 
     prepared = activity.copy()
 
@@ -41,15 +35,15 @@ def _prepare_activity(activity: pd.DataFrame) -> pd.DataFrame:
     if rename_map:
         prepared = prepared.rename(columns=rename_map)
 
-    for column, dtype in schema.items():
+    for column, dtype in ACTIVITY_SCHEMA.items():
         if column not in prepared.columns:
             if dtype == "boolean":
                 prepared[column] = False
             else:
                 prepared[column] = pd.NA
 
-    typed = coerce_types(prepared, schema)
-    return typed[list(schema.keys())]
+    typed = coerce_types(prepared, ACTIVITY_SCHEMA)
+    return typed[list(ACTIVITY_SCHEMA.keys())]
 
 
 def _aggregate_activity(
@@ -79,7 +73,15 @@ def _aggregate_activity(
             }
         )
 
-    activity = activity.copy()
+    required_columns = [
+        "document_chembl_id",
+        "activity_chembl_id",
+        "is_citation",
+        "assay_chembl_id",
+        "molecule_chembl_id",
+    ]
+    activity = ensure_columns(activity.copy(), required_columns, ACTIVITY_SCHEMA)
+    activity = coerce_types(activity, ACTIVITY_SCHEMA)
     activity = activity[activity["document_chembl_id"].notna()]
 
     grouped = (


### PR DESCRIPTION
## Summary
- centralize the document activity schema and reuse it for preparation and aggregation
- ensure aggregation fills and coerces required activity columns before grouping to avoid missing column errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d466f34ba08324a9c813222eb5d2d3