### PR TITLE
Ensure document postprocess fills missing output columns

### DIFF
--- a/library/postprocess_document.py
+++ b/library/postprocess_document.py
@@ -228,10 +228,25 @@ def run(inputs: Dict[str, pd.DataFrame], config: dict) -> pd.DataFrame:
     if "K_min_significant" in normalized.columns:
         normalized = normalized.drop(columns=["K_min_significant"])
 
-    column_types = config.get("pipeline", {}).get("document", {}).get("type_map", {})
+    document_cfg = config.get("pipeline", {}).get("document", {})
+    column_types = document_cfg.get("type_map", {})
+
+    required_columns: list[str] = []
+    if column_types:
+        required_columns.extend(column_types.keys())
+
+    column_order = document_cfg.get("column_order", [])
+    if column_order:
+        required_columns.extend(column_order)
+
+    if required_columns:
+        # Deduplicate while preserving the first occurrence order.
+        ordered_unique = list(dict.fromkeys(required_columns))
+        normalized = ensure_columns(normalized, ordered_unique, column_types)
+
     typed = coerce_types(normalized, column_types)
 
-    formatters = config.get("pipeline", {}).get("document", {}).get("formatters", {})
+    formatters = document_cfg.get("formatters", {})
     zero_pad = formatters.get("zero_pad", {})
     for column, width in zero_pad.items():
         if column in typed.columns:
@@ -247,10 +262,9 @@ def run(inputs: Dict[str, pd.DataFrame], config: dict) -> pd.DataFrame:
                 .astype("string")
             )
 
-    column_order = (
-        config.get("pipeline", {}).get("document", {}).get("column_order", [])
-    )
+    column_order = document_cfg.get("column_order", [])
     if column_order:
+        typed = ensure_columns(typed, column_order, column_types)
         missing = [col for col in column_order if col not in typed.columns]
         if missing:
             raise ValueError(f"Document output is missing columns: {missing}")


### PR DESCRIPTION
## Summary
- ensure the document post-processing normalizes required columns before type coercion
- reuse cached document pipeline configuration lookups instead of repeating nested gets
- pad the document output with required columns again immediately before enforcing column order

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d46a11fbb48324acd2a8566c9e7228