### PR TITLE
Align testitem columns with Power Query script

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -176,9 +176,11 @@ pipeline:
     type_map:
       molecule_chembl_id: string
       pref_name: string
+      all_names: string
       molecule_type: string
       structure_type: string
-      molecule_structures.standard_inchi_key: string
+      is_radical: bool
+      standard_inchi_key: string
       unknown_chirality: bool
       document_chembl_id: string
       document_testitem_total: Int64
@@ -186,9 +188,11 @@ pipeline:
     column_order:
       - molecule_chembl_id
       - pref_name
+      - all_names
       - molecule_type
       - structure_type
-      - molecule_structures.standard_inchi_key
+      - is_radical
+      - standard_inchi_key
       - unknown_chirality
       - document_chembl_id
       - document_testitem_total


### PR DESCRIPTION
## Summary
- align the test item column order and typing with the Power Query reference
- extend the post-processing schema to keep `all_names`, `is_radical`, and `standard_inchi_key`
- ensure the configured test item columns are present even when missing from the source feed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d47c1a85ac83248a670af1f78d8192