### PR TITLE
Load test item reference data into postprocessing pipeline

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,7 @@ files:
   activity_csv: "e:\github\ChEMBL_data_acquisition\data\output\activity\output.activity_20250921.csv"
   citation_fraction_csv: "e:\github\ChEMBL_data_acquisition\dictionary\_Curation\citation_fraction.csv"
   testitem_csv: "e:\github\ChEMBL_data_acquisition\data\output\testitem\output.testitem_20250925.csv"
+  testitem_reference_csv: "e:\github\ChEMBL_data_acquisition\data\output\testitem\output.testitem_reference_20250925.csv"
   assay_csv:    "e:\github\ChEMBL_data_acquisition\data\output\assay\output.assay_20250924.csv"
   target_csv:   "e:\github\ChEMBL_data_acquisition\data\output\target\output.targets_20250924.csv"
 

--- a/scripts/make_testitem_postprocessing.py
+++ b/scripts/make_testitem_postprocessing.py
@@ -26,11 +26,13 @@ def main() -> None:
     config = load_config(config_path)
 
     testitem_df = read_csv("testitem_csv", config)
+    testitem_reference_df = read_csv("testitem_reference_csv", config)
     activity_df = read_csv("activity_csv", config)
 
     result = run_testitem(
         {
             "testitem": testitem_df,
+            "testitem_reference": testitem_reference_df,
             "activity": activity_df,
         },
         config,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,8 +37,15 @@ def document_inputs(test_config: Dict[str, object]) -> Dict[str, pd.DataFrame]:
 def testitem_inputs(test_config: Dict[str, object]) -> Dict[str, pd.DataFrame]:
     base = Path(test_config["source"]["base_path"])
     testitem_df = pd.read_csv(base / test_config["files"]["testitem_csv"])
+    testitem_reference_df = pd.read_csv(
+        base / test_config["files"]["testitem_reference_csv"]
+    )
     activity_df = pd.read_csv(base / test_config["files"]["activity_csv"])
-    return {"testitem": testitem_df, "activity": activity_df}
+    return {
+        "testitem": testitem_df,
+        "testitem_reference": testitem_reference_df,
+        "activity": activity_df,
+    }
 
 
 @pytest.fixture()

--- a/tests/data/test_config.yaml
+++ b/tests/data/test_config.yaml
@@ -12,6 +12,7 @@ files:
   activity_csv: "activity.csv"
   citation_fraction_csv: "citation_fraction.csv"
   testitem_csv: "testitem.csv"
+  testitem_reference_csv: "testitem_reference.csv"
   assay_csv: "assay.csv"
   target_csv: "target.csv"
 

--- a/tests/data/testitem.csv
+++ b/tests/data/testitem.csv
@@ -1,3 +1,3 @@
 molecule_chembl_id,pref_name,all_names,molecule_type,structure_type,is_radical,standard_inchi_key,nstereo,document_chembl_id
-M1,Drug A,"Drug A|Compound A","Small molecule",MOL,false,KEY1,1,DOC1
-M3,Drug C,,Biologic,PROT,false,,2,DOC2
+M1,Drug A,,Small molecule,MOL,false,KEY1,,DOC1
+M3,Drug C,,Biologic,PROT,false,,,DOC2

--- a/tests/data/testitem_reference.csv
+++ b/tests/data/testitem_reference.csv
@@ -1,0 +1,3 @@
+molecule_chembl_id,all_names,nstereo
+M1,"Drug A|Compound A",1
+M3,,2


### PR DESCRIPTION
## Summary
- load the test item reference CSV from configuration and pass it into the post-processing CLI pipeline
- merge reference-sourced `all_names`/`nstereo` metadata during test item post-processing before downstream validations
- extend fixtures and sample data with the reference table for full pipeline coverage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d515cca9f4832495e7b7bb57906355