### PR TITLE
Disable configurable pipe sorting

### DIFF
--- a/library/postprocess_document.py
+++ b/library/postprocess_document.py
@@ -125,8 +125,6 @@ def _apply_classification_rules(df: pd.DataFrame, config: dict) -> pd.DataFrame:
     )
     if not rules:
         return df
-    sort_pipes = config.get("cleaning", {}).get("sort_pipes", True)
-
     result = df.copy()
     for rule in rules:
         column = rule.get("column")
@@ -139,7 +137,7 @@ def _apply_classification_rules(df: pd.DataFrame, config: dict) -> pd.DataFrame:
             result[column],
             alias_map=alias_map,
             drop_list=drop_list,
-            sort=bool(sort_pipes),
+            sort=False,
         )
     return result
 

--- a/library/postprocess_target.py
+++ b/library/postprocess_target.py
@@ -244,7 +244,7 @@ def run(inputs: Dict[str, pd.DataFrame], config: dict) -> pd.DataFrame:
             target_df["synonyms"],
             alias_map=None,
             drop_list=None,
-            sort=config.get("cleaning", {}).get("sort_pipes", True),
+            sort=False,
         )
 
     output_columns = (

--- a/tests/test_postprocess_target.py
+++ b/tests/test_postprocess_target.py
@@ -22,9 +22,9 @@ def test_target_postprocess(target_inputs, test_config) -> None:
             ],
             "gene_name": ["gene1", "betagene", "gammagene"],
             "synonyms": [
-                "alpha canonical|alpha pref|alt a|altalpha|ga|gene1|subunit alpha",
+                "alpha canonical|alpha pref|altalpha|alt a|ga|gene1|subunit alpha",
                 "beta canonical|beta pref",
-                "gamma alt|gamma canonical|gamma subunit|gg|gg1",
+                "gamma canonical|gamma alt|gg|gg1|gamma subunit",
             ],
             "protein_class_pred_L1": [
                 "Enzyme",


### PR DESCRIPTION
## Summary
- always call `clean_pipe` with `sort=False` so that incoming token order is preserved
- update document and target post-processing to ignore `cleaning.sort_pipes`
- adjust the target post-processing test expectations to match the unsorted synonym order

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d518a5bb108324abfe11122a99abe9