### PR TITLE
Adjust review detection to substring match

### DIFF
--- a/library/postprocess_document.py
+++ b/library/postprocess_document.py
@@ -164,8 +164,7 @@ def _compute_review(row: pd.Series, base_weight: int, threshold: float) -> bool:
     n_responses = row.get("n_responces", 1)
 
     def contains_review(value: str) -> bool:
-        tokens = [token.strip() for token in value.split("|") if token.strip()]
-        return "review" in tokens
+        return "review" in value
 
     vote_score = (
         int(contains_review(pub_type))


### PR DESCRIPTION
## Summary
- update the document post-processing review detection helper to search for the review substring rather than token equality, aligning with Power Query Text.Contains behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d518cf66248324b45d3395467c19dd