### PR TITLE
Rename document columns before ensuring schema

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -106,6 +106,14 @@ pipeline:
         - "scholar.PublicationTypes"
         - "OpenAlex.publication_type"
         - "OpenAlex.crossref_type"
+    rename_map:
+      _title: title
+      abstract_: abstract
+      MeSH.descriptors: "PubMed.MeSH"
+      OpenAlex.MeSH.descriptors: "OpenAlex.MeSH"
+      PubMed.MeSH_Qualifiers: "MeSH.qualifiers"
+      PubMed.ChemicalList: chemical_list
+      publication_type: "PubMed.publication_type"
     type_map:
       PMID: Int64
       doi: string

--- a/library/postprocess_document.py
+++ b/library/postprocess_document.py
@@ -20,6 +20,17 @@ ACTIVITY_SCHEMA = {
 }
 
 
+DOCUMENT_RENAME_MAP = {
+    "_title": "title",
+    "abstract_": "abstract",
+    "MeSH.descriptors": "PubMed.MeSH",
+    "OpenAlex.MeSH.descriptors": "OpenAlex.MeSH",
+    "PubMed.MeSH_Qualifiers": "MeSH.qualifiers",
+    "PubMed.ChemicalList": "chemical_list",
+    "publication_type": "PubMed.publication_type",
+}
+
+
 def _prepare_activity(activity: pd.DataFrame) -> pd.DataFrame:
     if activity.empty:
         return pd.DataFrame(columns=ACTIVITY_SCHEMA.keys()).astype(ACTIVITY_SCHEMA)
@@ -231,6 +242,10 @@ def run(inputs: Dict[str, pd.DataFrame], config: dict) -> pd.DataFrame:
     if "K_min_significant" in normalized.columns:
         normalized = normalized.drop(columns=["K_min_significant"])
 
+
+    rename_map = document_cfg.get("rename_map", DOCUMENT_RENAME_MAP)
+    if rename_map:
+        normalized = normalized.rename(columns=rename_map)
 
     column_types = document_cfg.get("type_map", {})
     column_order = document_cfg.get("column_order", [])


### PR DESCRIPTION
## Summary
- add a configurable rename_map for document post-processing so legacy column names are normalized
- apply the rename map before type coercion and column enforcement to preserve values in renamed columns

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d518eaa42083248e06b5d4537ec649