### PR TITLE
Align testitem normalization with Power Query behavior

### DIFF
--- a/tests/test_postprocess_testitem.py
+++ b/tests/test_postprocess_testitem.py
@@ -13,12 +13,12 @@ def test_testitem_postprocess(testitem_inputs, test_config) -> None:
     expected = pd.DataFrame(
         {
             "molecule_chembl_id": ["M1", "M3"],
-            "pref_name": ["Drug A", "Drug C"],
-            "all_names": ["Drug A|Compound A", ""],
+            "pref_name": ["drug a", "drug c"],
+            "all_names": ["compound a|drug a", pd.NA],
             "molecule_type": ["Small molecule", "Biologic"],
             "structure_type": ["MOL", "PROT"],
             "is_radical": [False, False],
-            "standard_inchi_key": ["KEY1", ""],
+            "standard_inchi_key": ["KEY1", pd.NA],
             "unknown_chirality": [False, True],
             "document_chembl_id": ["DOC1", "DOC2"],
             "document_testitem_total": [2, 1],


### PR DESCRIPTION
## Summary
- align testitem aggregation with Power Query semantics by distincting document/molecule pairs before grouping
- normalize pref_name and all_names columns via new helpers to reproduce LowercaseColumns behavior and preserve nulls
- make invalid record checks case-sensitive with fallback to standard_inchi_key and refresh expectations in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d51901ab8c83248f0a3adbc14af22f