### PR TITLE
Refine document pipeline input loading

### DIFF
--- a/tests/test_make_document_postprocessing.py
+++ b/tests/test_make_document_postprocessing.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pandas as pd
+
+from library.config import load_config
+from scripts.make_document_postprocessing import get_document_data
+
+
+def test_get_document_data_loads_inputs() -> None:
+    config = load_config(Path("tests/data/test_config.yaml"))
+
+    data = get_document_data(config)
+
+    expected_keys = {
+        "document",
+        "document_out",
+        "document_reference",
+        "activity",
+        "citation_fraction",
+    }
+    assert set(data.keys()) == expected_keys
+    assert all(isinstance(frame, pd.DataFrame) for frame in data.values())
+    assert list(data["citation_fraction"].columns) == [
+        "N",
+        "K_min_significant",
+        "test_used_at_threshold",
+        "p_value_at_threshold",
+    ]
+
+
+def test_get_document_data_uses_document_fallback() -> None:
+    config = load_config(Path("tests/data/test_config.yaml"))
+    config_fallback = copy.deepcopy(config)
+    config_fallback["files"].pop("document_reference_csv")
+
+    data = get_document_data(config_fallback)
+
+    assert data["document_reference"] is data["document"]


### PR DESCRIPTION
## Summary
- add a reusable `get_document_data` helper to load all inputs for the document pipeline with proper fallbacks
- ensure the CLI reuses the helper so the citation fraction dataset is passed as a DataFrame rather than a path key
- cover the helper with tests, including the fallback behaviour for missing reference keys

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d53aae98648324b70057f06c01b630