### PR TITLE
Normalize completed date component without dropping non-digits

### DIFF
--- a/library/postprocess_document.py
+++ b/library/postprocess_document.py
@@ -284,9 +284,7 @@ def _build_completed(row: pd.Series) -> str:
         text = to_text(value)
         if not text:
             return "0" * digits
-        digits_only = _sanitize_digits(text)
-        normalized = digits_only or text
-        return normalized.zfill(digits)
+        return text.zfill(digits)
 
     completed_year = component("completed.year", 4)
     completed_month = component("completed.month", 2)


### PR DESCRIPTION
## Summary
- align completed date component normalization with the Power Query behaviour by trimming and zero-filling without stripping non-digit characters

## Testing
- pytest tests/test_postprocess_document.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d54c0ca9c48324a5fd7929472d7032