### PR TITLE
Remove document fields from testitem export

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -183,8 +183,6 @@ pipeline:
       is_radical: bool
       standard_inchi_key: string
       unknown_chirality: bool
-      document_chembl_id: string
-      document_testitem_total: Int64
       invalid_record: bool
     column_order:
       - molecule_chembl_id
@@ -195,8 +193,6 @@ pipeline:
       - is_radical
       - standard_inchi_key
       - unknown_chirality
-      - document_chembl_id
-      - document_testitem_total
       - invalid_record
   assay:
     drop_columns:

--- a/data/output/testitem_postprocessed.csv
+++ b/data/output/testitem_postprocessed.csv
@@ -1,21 +1,21 @@
-molecule_chembl_id,pref_name,all_names,molecule_type,structure_type,is_radical,standard_inchi_key,unknown_chirality,document_chembl_id,document_testitem_total,invalid_record
-CHEMBL417915,,(-)-cymserine,Small molecule,MOL,,NKJRRVBTMYRXRB-YANBTOMASA-N,True,,0,False
-CHEMBL296435,(+)-ehna,(+)-ehna,Small molecule,MOL,,IOSAAWHGJUZBOG-WDEREUQCSA-N,False,,0,False
-CHEMBL27559,,(r)-oh-n-propylnoraporphine,Small molecule,MOL,,WZJSIHGOLMMBAL-MRXNPFEDSA-N,False,,0,False
-CHEMBL267447,calanolide a,(+)-calanolide a,Small molecule,MOL,,NIDRYBLTWYFCFV-FMTVUPSXSA-N,False,,0,False
-CHEMBL416715,(r)pk-11195,(r)pk-11195,Small molecule,MOL,,RAVIZVQZGXBOQO-CQSZACIVSA-N,False,,0,False
-CHEMBL54727,,(-)-phenserine,Small molecule,MOL,,PBHFNBQPZCRWQP-IJHRGXPZSA-N,True,,0,False
-CHEMBL51697,,(s)-nomifensine,Small molecule,MOL,,XXPANQJNYNUNES-AWEZNQCLSA-N,False,,0,False
-CHEMBL284994,,"(1r,4s)-trans-sertraline",Small molecule,MOL,,VGKDLMBJGBXTGI-YVEFUNNKSA-N,False,,0,False
-CHEMBL283509,,(+)-arisugacin a,Small molecule,MOL,,MIHBCQWIBJDVPX-JUDWXZBOSA-N,False,,0,False
-CHEMBL268229,,(r)-alpha-methylhistamine,Small molecule,MOL,,XNQIOISZPFVUFG-RXMQYKEDSA-N,False,,0,False
-CHEMBL49623,"(r,s)-ifenprodil","(r,s)-ifenprodil",Small molecule,MOL,,UYNVMODNBIQBMV-KKSFZXQISA-N,False,,0,False
-CHEMBL11919,,(s)-alpha-methylhistamine,Small molecule,MOL,,XNQIOISZPFVUFG-YFKPBYRVSA-N,False,,0,False
-CHEMBL300143,,(-)-tolserine,Small molecule,MOL,,JGAGHIIOCADQOV-QWAKEFERSA-N,True,,0,False
-CHEMBL13378,"(r,s)-ampa","(r,s)-ampa",Small molecule,MOL,,UUDAMDVQRQNNHZ-UHFFFAOYSA-N,True,,0,False
-CHEMBL276815,(s)-ampa,(s)-ampa,Small molecule,MOL,,UUDAMDVQRQNNHZ-YFKPBYRVSA-N,False,,0,False
-CHEMBL46005,,"(2s,2's)-2,2'-carbonylbis(azanediyl)dipentanedioic acid",Small molecule,MOL,,SOAPXKSPJAZNGO-WDSKDSINSA-N,False,,0,False
-CHEMBL298827,(s)-thiorphan,(s)-thiorphan,Small molecule,MOL,,LJJKNPQAGWVLDQ-SNVBAGLBSA-N,False,,0,False
-CHEMBL66,(+)-taxifolin,"(+)-taxifolin, cianidanol",Small molecule,MOL,,CXQWRCVTCMQVQX-LSDHHAIUSA-N,False,,0,False
-CHEMBL24077,(r)-skf-38393,"(r)-skf-38393, (r)-skf-38393",Small molecule,MOL,,JUDKOGFHZYMDMF-CQSZACIVSA-N,False,,0,False
-CHEMBL14346,"1,2,3,4-tetrahydroisoquinoline","1,2,3,4-tetrahydroisoquinoline, 1,2,3,4-tetrahydro-isoquinoline, 1,2,3,4-tetrahydroisoquinoline",Small molecule,MOL,,UWYZHKAOTLEWKK-UHFFFAOYSA-N,False,,0,False
+molecule_chembl_id,pref_name,all_names,molecule_type,structure_type,is_radical,standard_inchi_key,unknown_chirality,invalid_record
+CHEMBL417915,,(-)-cymserine,Small molecule,MOL,,NKJRRVBTMYRXRB-YANBTOMASA-N,True,False
+CHEMBL296435,(+)-ehna,(+)-ehna,Small molecule,MOL,,IOSAAWHGJUZBOG-WDEREUQCSA-N,False,False
+CHEMBL27559,,(r)-oh-n-propylnoraporphine,Small molecule,MOL,,WZJSIHGOLMMBAL-MRXNPFEDSA-N,False,False
+CHEMBL267447,calanolide a,(+)-calanolide a,Small molecule,MOL,,NIDRYBLTWYFCFV-FMTVUPSXSA-N,False,False
+CHEMBL416715,(r)pk-11195,(r)pk-11195,Small molecule,MOL,,RAVIZVQZGXBOQO-CQSZACIVSA-N,False,False
+CHEMBL54727,,(-)-phenserine,Small molecule,MOL,,PBHFNBQPZCRWQP-IJHRGXPZSA-N,True,False
+CHEMBL51697,,(s)-nomifensine,Small molecule,MOL,,XXPANQJNYNUNES-AWEZNQCLSA-N,False,False
+CHEMBL284994,,"(1r,4s)-trans-sertraline",Small molecule,MOL,,VGKDLMBJGBXTGI-YVEFUNNKSA-N,False,False
+CHEMBL283509,,(+)-arisugacin a,Small molecule,MOL,,MIHBCQWIBJDVPX-JUDWXZBOSA-N,False,False
+CHEMBL268229,,(r)-alpha-methylhistamine,Small molecule,MOL,,XNQIOISZPFVUFG-RXMQYKEDSA-N,False,False
+CHEMBL49623,"(r,s)-ifenprodil","(r,s)-ifenprodil",Small molecule,MOL,,UYNVMODNBIQBMV-KKSFZXQISA-N,False,False
+CHEMBL11919,,(s)-alpha-methylhistamine,Small molecule,MOL,,XNQIOISZPFVUFG-YFKPBYRVSA-N,False,False
+CHEMBL300143,,(-)-tolserine,Small molecule,MOL,,JGAGHIIOCADQOV-QWAKEFERSA-N,True,False
+CHEMBL13378,"(r,s)-ampa","(r,s)-ampa",Small molecule,MOL,,UUDAMDVQRQNNHZ-UHFFFAOYSA-N,True,False
+CHEMBL276815,(s)-ampa,(s)-ampa,Small molecule,MOL,,UUDAMDVQRQNNHZ-YFKPBYRVSA-N,False,False
+CHEMBL46005,,"(2s,2's)-2,2'-carbonylbis(azanediyl)dipentanedioic acid",Small molecule,MOL,,SOAPXKSPJAZNGO-WDSKDSINSA-N,False,False
+CHEMBL298827,(s)-thiorphan,(s)-thiorphan,Small molecule,MOL,,LJJKNPQAGWVLDQ-SNVBAGLBSA-N,False,False
+CHEMBL66,(+)-taxifolin,"(+)-taxifolin, cianidanol",Small molecule,MOL,,CXQWRCVTCMQVQX-LSDHHAIUSA-N,False,False
+CHEMBL24077,(r)-skf-38393,"(r)-skf-38393, (r)-skf-38393",Small molecule,MOL,,JUDKOGFHZYMDMF-CQSZACIVSA-N,False,False
+CHEMBL14346,"1,2,3,4-tetrahydroisoquinoline","1,2,3,4-tetrahydroisoquinoline, 1,2,3,4-tetrahydro-isoquinoline, 1,2,3,4-tetrahydroisoquinoline",Small molecule,MOL,,UWYZHKAOTLEWKK-UHFFFAOYSA-N,False,False

--- a/docs/OUTPUT.md
+++ b/docs/OUTPUT.md
@@ -15,8 +15,7 @@ Columns, ordering and data types are enforced by ``pipeline.*.type_map`` and
 ## Test item
 
 * Primary key: ``molecule_chembl_id``.
-* Enrichments: ``document_testitem_total`` (per-document molecule count) and
-  ``invalid_record`` (quality flag driven by the config rules).
+* Enrichments: ``invalid_record`` (quality flag driven by the config rules).
 * ``unknown_chirality`` converts the Power Query logic to boolean flags.
 
 ## Assay

--- a/tests/data/test_config.yaml
+++ b/tests/data/test_config.yaml
@@ -171,8 +171,6 @@ pipeline:
       is_radical: bool
       standard_inchi_key: string
       unknown_chirality: bool
-      document_chembl_id: string
-      document_testitem_total: Int64
       invalid_record: bool
     column_order:
       - molecule_chembl_id
@@ -183,8 +181,6 @@ pipeline:
       - is_radical
       - standard_inchi_key
       - unknown_chirality
-      - document_chembl_id
-      - document_testitem_total
       - invalid_record
   assay:
     drop_columns:

--- a/tests/test_postprocess_testitem.py
+++ b/tests/test_postprocess_testitem.py
@@ -20,8 +20,6 @@ def test_testitem_postprocess(testitem_inputs, test_config) -> None:
             "is_radical": [False, False],
             "standard_inchi_key": ["KEY1", pd.NA],
             "unknown_chirality": [False, True],
-            "document_chembl_id": ["DOC1", "DOC2"],
-            "document_testitem_total": [2, 1],
             "invalid_record": [False, True],
         }
     )


### PR DESCRIPTION
## Summary
- stop emitting document_chembl_id and document_testitem_total from the testitem post-processing output
- align pipeline configuration, tests, and documentation with the trimmed schema
- refresh the sample CSV snapshot to match the new column set

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5662974b883248d27f80450807450