### PR TITLE
Use document_csv for document outputs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,6 @@ files:
   activity_csv: "e:\github\ChEMBL_data_acquisition\data\output\activity\output.activity_20250921.csv"  
   assay_csv:    "e:\github\ChEMBL_data_acquisition\data\output\assay\output.assay_20250924.csv"
   target_csv:   "e:\github\ChEMBL_data_acquisition\data\output\target\output.targets_20250924.csv"
-  document_out_csv: "e:\github\ChEMBL_data_acquisition\data\output\document\output.document_20250924.csv"
 
 io:
   encoding_in: utf8

--- a/scripts/make_document_postprocessing.py
+++ b/scripts/make_document_postprocessing.py
@@ -56,7 +56,7 @@ def get_document_data(config: Dict[str, object]) -> Dict[str, pd.DataFrame]:
 
     document_ref_key = _resolve_key(files_cfg, "document_reference_csv", "document_csv")
     document_out_key = _resolve_key(
-        files_cfg, "document_out_csv", "document_reference_csv", "document_csv"
+        files_cfg, "document_out_csv", "document_csv", "document_reference_csv"
     )
     activity_ref_key = _resolve_key(files_cfg, "activity_reference_csv", "activity_csv")
     citation_key = _resolve_key(
@@ -69,7 +69,9 @@ def get_document_data(config: Dict[str, object]) -> Dict[str, pd.DataFrame]:
         document_ref_df = read_csv(document_ref_key, config)
         document_ref_df = _drop_columns(document_ref_df, EXCLUDED_COLUMNS)
 
-    if document_out_key == document_ref_key:
+    if document_out_key == "document_csv":
+        document_out_df = document_df
+    elif document_out_key == document_ref_key:
         document_out_df = document_ref_df
     else:
         document_out_df = read_csv(document_out_key, config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,8 +23,13 @@ def test_config() -> Dict[str, object]:
 @pytest.fixture()
 def document_inputs(test_config: Dict[str, object]) -> Dict[str, pd.DataFrame]:
     base = Path(test_config["source"]["base_path"])
-    document_df = pd.read_csv(base / test_config["files"]["document_csv"])
-    document_out_df = pd.read_csv(base / test_config["files"]["document_out_csv"])
+    files_cfg = test_config["files"]
+    document_df = pd.read_csv(base / files_cfg["document_csv"])
+    document_out_path = files_cfg.get("document_out_csv")
+    if document_out_path:
+        document_out_df = pd.read_csv(base / document_out_path)
+    else:
+        document_out_df = document_df
     document_reference_df = pd.read_csv(
         base / test_config["files"]["document_reference_csv"]
     )

--- a/tests/data/test_config.yaml
+++ b/tests/data/test_config.yaml
@@ -8,8 +8,7 @@ source:
     auth: env
 
 files:
-  document_csv: "document.csv"
-  document_out_csv: "document_out.csv"
+  document_csv: "document_out.csv"
   document_reference_csv: "document_reference.csv"
   activity_csv: "activity.csv"
   citation_fraction_csv: "citation_fraction.csv"

--- a/tests/test_make_document_postprocessing.py
+++ b/tests/test_make_document_postprocessing.py
@@ -23,6 +23,7 @@ def test_get_document_data_loads_inputs() -> None:
     }
     assert set(data.keys()) == expected_keys
     assert all(isinstance(frame, pd.DataFrame) for frame in data.values())
+    assert data["document_out"] is data["document"]
     assert list(data["citation_fraction"].columns) == [
         "N",
         "K_min_significant",
@@ -49,3 +50,4 @@ def test_get_document_data_uses_document_fallback() -> None:
     data = get_document_data(config_fallback)
 
     assert data["document_reference"] is data["document"]
+    assert data["document_out"] is data["document"]


### PR DESCRIPTION
## Summary
- remove the redundant `document_out_csv` entry from configuration, relying on `document_csv`
- update `get_document_data` to reuse `document_csv` when no separate document output path is provided
- adjust fixtures and tests to match the new configuration and verify the fallback behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d568e8f380832493568b8b5e6ede9c